### PR TITLE
Support github workflow automatic backporting

### DIFF
--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -1,0 +1,35 @@
+###############################################################################
+#
+# Copyright IBM Corp. 2024
+#
+# Licensed under the Apache License 2.0 (the "License").  You may not use
+# this file except in compliance with the License.  You can obtain a copy
+# in the file LICENSE in the source distribution.
+#
+###############################################################################
+name: Automatic Backport
+
+on:
+  pull_request_target:
+    types: ["labeled", "closed"]
+
+jobs:
+  backport:
+    name: Backport PR
+    if: github.event.pull_request.merged == true && !(contains(github.event.pull_request.labels.*.name, 'backport'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Backport Action
+        uses: sorenlouv/backport-github-action@v9.5.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          auto_backport_label_prefix: backport-to-
+
+      - name: Info log
+        if: ${{ success() }}
+        run: cat ~/.backport/backport.info.log
+        
+      - name: Debug log
+        if: ${{ failure() }}
+        run: cat ~/.backport/backport.debug.log        
+          

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,6 +1,6 @@
 ###############################################################################
 #
-# Copyright IBM Corp. 2023
+# Copyright IBM Corp. 2023, 2024
 #
 # Licensed under the Apache License 2.0 (the "License").  You may not use
 # this file except in compliance with the License.  You can obtain a copy
@@ -8,7 +8,7 @@
 #
 ###############################################################################
 
-name: GitHub Actions OpenJCEPlus
+name: Build And Test
 run-name: ${{ github.actor }} is building and testing OpenJCEPlus 🚀
 on: [pull_request]
 jobs:

--- a/backportrc.json
+++ b/backportrc.json
@@ -1,0 +1,21 @@
+// ###############################################################################
+// #
+// # Copyright IBM Corp. 2024
+// #
+// # Licensed under the Apache License 2.0 (the "License").  You may not use
+// # this file except in compliance with the License.  You can obtain a copy
+// # in the file LICENSE in the source distribution.
+// #
+// ###############################################################################
+//
+// This file contains configurations related to automatic backporting
+//
+{
+  // The branches available to backport to.
+  "targetBranchChoices": ["java23","java21","java17","java11"],
+
+  // The labels that trigger a backport. For example adding the label "backport-to-java21" will backport the PR to the "java21" branch.
+  "branchLabelMapping": {
+    "^backport-to-(.+)$": "$1"
+  }
+}


### PR DESCRIPTION
This workflow allows for pull requests to be backported automatically by adding a label to a PR after it has been merged. For example to backport a PR that has been merged to main simply add the label `backport-to-java21` to the PR in order to perform the backport. This will result in a new PR made against the target branch as specified by the label.

The build and test github action file was also named accordingly since we now have to workflows for the project.